### PR TITLE
Fixed library exception when spec test contains syntax error

### DIFF
--- a/src/Listener/DataProviderListener.php
+++ b/src/Listener/DataProviderListener.php
@@ -7,6 +7,7 @@ namespace DBorsatto\PhpSpec\DataProvider\Listener;
 use DBorsatto\PhpSpec\DataProvider\Annotation\Parser;
 use PhpSpec\Event\SpecificationEvent;
 use PhpSpec\Loader\Node\ExampleNode;
+use ReflectionMethod;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use function is_array;
 
@@ -23,6 +24,11 @@ class DataProviderListener implements EventSubscriberInterface
     {
         $examplesToAdd = [];
         foreach ($event->getSpecification()->getExamples() as $example) {
+            $functionReflection = $example->getFunctionReflection();
+            if (!$functionReflection instanceof ReflectionMethod) {
+                continue;
+            }
+
             $dataProviderMethod = Parser::getDataProvider($example->getFunctionReflection());
             if ($dataProviderMethod === null) {
                 continue;
@@ -49,7 +55,7 @@ class DataProviderListener implements EventSubscriberInterface
             foreach ($providedData as $index => $dataRow) {
                 $examplesToAdd[] = new ExampleNode(
                     $index + 1 . ') ' . $example->getTitle(),
-                    $example->getFunctionReflection()
+                    $functionReflection
                 );
             }
         }


### PR DESCRIPTION
When a spec file contains a syntax error (for example, a missing comma or an extra parenthesis), the library throws an exception like:
>     Uncaught TypeError: Argument 1 passed to DBorsatto\PhpSpec\DataProvider\Annotation\Parser::getDataProvider() must be an instance of ReflectionMethod, instance of ReflectionFunction given, called in /var/www/app/vendor/dborsatto/phpspec-data-provider-extension/src/Listener/DataProviderListener.php on line 26 and defined in /var/www/app/vendor/dborsatto/phpspec-data-provider-extension/src/Annotation/Parser.php:13
>     Stack trace:
>     #0 /var/www/app/vendor/dborsatto/phpspec-data-provider-extension/src/Listener/DataProviderListener.php(26): DBorsatto\PhpSpec\DataProvider\Annotation\Parser::getDataProvider(Object(ReflectionFunction))
>     #1 /var/www/app/vendor/symfony/event-dispatcher/EventDispatcher.php(230): DBorsatto\PhpSpec\DataProvider\Listener\DataProviderListener->beforeSpecification(Object(PhpSpec\Event\SpecificationEvent), 'beforeSpecifica...', Object(Symfony\Component\EventDispatcher\EventDispatcher))
>     #2 /var/www/app/vendor/symfony/event-dispatcher/EventDispatcher.php(59): Symfony\Component\EventDispatcher\EventDis in /var/www/app/vendor/dborsatto/phpspec-data-provider-extension/src/Annotation/Parser.php on line 13 

instead of letting the PHP interpreter show the correct error. For example: 
`syntax error, unexpected ')', expecting variable (T_VARIABLE)`

The problem is caused by the wrong type of variable being provided to Parser::getDataProvider. I added an extra check to ensure this does not happen.